### PR TITLE
__repr__ 오류 수정

### DIFF
--- a/Database/models.py
+++ b/Database/models.py
@@ -140,7 +140,7 @@ class LoginSessionsTable(Base):
                 f"<LoginSession(xid='{self.xid}', " +
                 f"user_id='{self.user_id}', " +
                 f"last_active='{self.last_active}', " +
-                f"is_main_user='{self.is_main_user}, " +
+                f"is_main_user='{self.is_main_user}', " +
                 f"is_remember='{self.is_remember}')>"
                 )
 
@@ -330,7 +330,7 @@ class NotificationsTable(Base):
                 f"notification_grade='{self.notification_grade}', " +
                 f"descriptions='{self.descriptions}', " +
                 f"message_sn='{self.message_sn}', " +
-                f"is_read='{self.is_read}," +
+                f"is_read='{self.is_read}', " +
                 f"image_url='{self.image_url}')>"
         )
 


### PR DESCRIPTION
## 요약
- `NotificationsTable`의 `__repr__` 메서드에서 쉼표 뒤 공백이 누락된 부분을 수정했습니다.

## 테스트
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f92885570832f8106286fac760e56